### PR TITLE
Adicionado configuracao para rodar com o docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+# v2 sintax
+version: '2'
+
+# Named volumes
+volumes:
+  # MySQL Data
+  gitscrum-mysql-data:
+    driver: local
+
+services:
+  # MySQL (5.7)
+  mysql:
+    image: ambientum/mysql:5.7
+    container_name: gitscrum-mysql
+    volumes:
+      - gitscrum-mysql-data:/var/lib/mysql
+    ports:
+      - "3307:3306"
+    environment:
+      - MYSQL_ROOT_PASSWORD=gitscrum
+      - MYSQL_DATABASE=gitscrum
+      - MYSQL_USER=gitscrum
+      - MYSQL_PASSWORD=gitscrum
+
+  web:
+    image: ambientum/php:7.0-apache
+    container_name: gitscrum-web
+    volumes:
+      - .:/var/www/app
+    ports:
+      - "80:8080"
+    links:
+      - mysql


### PR DESCRIPTION
Adicionado configuracao para rodar com o docker compose.

Com isso basta instalar o docker e executar o comando abaixo para subir a máquina

`docker-compose up`

Depois disso basta acessar a aplicação com através da url http://localhost

O mysql pode sera acessado na porta 3307 no host localhost